### PR TITLE
escape \ to ensure RUN wget parsed as single line. Resolves #4

### DIFF
--- a/R/write_dockerfile.R
+++ b/R/write_dockerfile.R
@@ -30,7 +30,7 @@ write_dockerfile <-
     line4 = "## Become normal user again"
     line5 = "USER ${NB_USER}"
     line6 = glue(
-      "RUN wget https://github.com/{user}/{repo}/raw/master/DESCRIPTION && \
+      "RUN wget https://github.com/{user}/{repo}/raw/master/DESCRIPTION && \\\
 R -e \"devtools::install_deps()\""
     )
     df <- readLines("Dockerfile")


### PR DESCRIPTION
Hey @karthik,

Just pushing a quick fix to resolve the `RUN wget ...` parsing error I was getting with `write_dockerfile()` (see #4 ) 