### PR TITLE
clarify write_requirements description

### DIFF
--- a/R/write_requirements.R
+++ b/R/write_requirements.R
@@ -3,9 +3,9 @@
 
 
 
-#' write a list of Python requirements
+#' Write a list of Python requirements
 #'
-#' Writes a list of Debian packages that should be installed. Caution: If you have a Dockerfile,
+#' Writes a list of Python packages that should be installed. Caution: If you have a Dockerfile,
 #' this file will be ignored.
 #'
 #' @param path Path to project


### PR DESCRIPTION
Just a tiny edit, when looking for how to declare system dependencies (found `write_apt` in the end), noticed this mix up in the title vs description for `write_requirements`. 

Thanks!