### PR TITLE
Bug fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: holepunch
 Title: Configure Your R Project for 'binderhub'
-Version: 0.1.28.9000
+Version: 0.1.29.9000
 Authors@R: 
     c(person(given = "Karthik",
            family = "Ram",

--- a/R/write_installer.R
+++ b/R/write_installer.R
@@ -20,7 +20,7 @@ write_install <- function(path = ".") {
   packages <- get_dependencies(path)
   res <- paste0("  \"", packages)
   res <- paste0(res, collapse =  "\",\n")
-  res <- paste0("install.packages(\n", res, "\"\n)")
+  res <- paste0("install.packages(\n c( \n", res, "\")\n)")
   fs::dir_create(glue("{path}/.binder"))
   usethis::write_over(glue("{path}/.binder/install.R"), res)
 }

--- a/tests/testthat/test-write_install.R
+++ b/tests/testthat/test-write_install.R
@@ -44,12 +44,13 @@ glue::glue_collapse(glue::glue('{1:10}'))
   # Problem here. Write install is not finding all packages.
   packages_needed_here <- c(
     "install.packages(",
+    " c( ",
     "  \"dplyr\",",
     "  \"ggplot2\",",
     "  \"glue\",",
     "  \"purrr\",",
     "  \"rmarkdown\",",
-    "  \"tidyr\"", 
+    "  \"tidyr\")", 
     ")"
   )
   


### PR DESCRIPTION
Fixed `write_install` which requires a vector of package names. 

Before the function was generated package names separated by commas and those passed as unnamed arguments to `write_install` which failed to run on binder.

The function now creates a vector of package names and `install.R` now  runs successfully on mybinder

Also amended test and bumped version