### PR TITLE
Fix write dockerfile

### DIFF
--- a/R/write_dockerfile.R
+++ b/R/write_dockerfile.R
@@ -114,9 +114,7 @@ write_dockerfile <-
       "
 FROM [base]
 LABEL maintainer='[MAINTAINER]'
-USER root
-COPY . ${HOME}
-RUN chown -R ${NB_USER} ${HOME}
+COPY --chown=${NB_USER} . ${HOME}
 USER ${NB_USER}
 
 [remote_cmd]

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -190,7 +190,7 @@ r_version_lookup <- function(date = NULL) {
     if (date < df[1, 2]) {
       stop("Canot find R version for this date", call. = FALSE)
     }
-    ver <- tail(df$version[date > df$date], 1)
+    ver <- utils::tail(df$version[date > df$date], 1)
   } else {
     "latest"
   }

--- a/tests/testthat/test-write_dockerfile.R
+++ b/tests/testthat/test-write_dockerfile.R
@@ -8,9 +8,8 @@ test_that("Writing Dockerfile works", {
     readLines(glue::glue("{temp_path}/.binder/Dockerfile"))
 
   expect_identical(reading_back_dockerfile[2], "LABEL maintainer='Wes Anderson'")
-  expect_identical(reading_back_dockerfile[3], "USER root")
-  expect_identical(reading_back_dockerfile[4], "COPY . ${HOME}")
-  expect_identical(reading_back_dockerfile[5], "RUN chown -R ${NB_USER} ${HOME}")
+  expect_identical(reading_back_dockerfile[3], "COPY --chown=${NB_USER} . ${HOME}")
+  expect_identical(reading_back_dockerfile[4], "USER ${NB_USER}")
 
   unlink(temp_path)
   setwd(old_path)


### PR DESCRIPTION
This addresses problems with rendering Rmds to pdfs on mybinder which was throwing errors related to access rights with the previous version of the dockerfile.

The solution was taken from https://github.com/rocker-org/binder/blob/master/Dockerfile 

Also added missing namespace to the `tail()` call introduced in previous PRs.